### PR TITLE
Don't use a 2 year old fork of revealjs to fix the head.js dependency issue

### DIFF
--- a/slides/ros-training.el
+++ b/slides/ros-training.el
@@ -78,7 +78,7 @@
          :publishing-directory ,(concat proj-base "../html/docs/")
          :publishing-function org-gfm-publish-to-gfm
          :exclude-tags ("slides")))
-    org-reveal-root "https://robojackets.github.io/reveal.js/"
+    org-reveal-root "https://revealjs.com"
     org-reveal-margin "0.15"))
 
 


### PR DESCRIPTION
Okay, right now the slides use org-reveal. We've got a forked version of reveal.js (that's 2 years old) which relies on a dependency `head.js` which is no longer being maintained. 

This results in none of the presentations working due to a `head is not defined` being spit out by the console.

This PR changes the build process to use the upstream version of reveal.js, which works.