### PR TITLE
Cleaned up week 2, created missing safety_node cpp, structured slides better

### DIFF
--- a/code/igvc_training_exercises/src/week2/CMakeLists.txt
+++ b/code/igvc_training_exercises/src/week2/CMakeLists.txt
@@ -22,3 +22,8 @@ add_executable(week2_even_publisher exercises/even_publisher.cpp)
 target_include_directories(week2_even_publisher PRIVATE ${catkin_INCLUDE_DIRS})
 target_link_libraries(week2_even_publisher ${catkin_LIBRARIES})
 add_dependencies(week2_even_publisher ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+add_executable(week2_safety_node exercises/safety_node.cpp)
+target_include_directories(week2_safety_node PRIVATE ${catkin_INCLUDE_DIRS})
+target_link_libraries(week2_safety_node ${catkin_LIBRARIES})
+add_dependencies(week2_safety_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/code/igvc_training_exercises/src/week2/exercises/safety_node.cpp
+++ b/code/igvc_training_exercises/src/week2/exercises/safety_node.cpp
@@ -1,0 +1,3 @@
+int main(int argc, char** argv)
+{
+}

--- a/code/instructions/week2.md
+++ b/code/instructions/week2.md
@@ -8,7 +8,7 @@ figure out how we can write a node in C++ first.
 
 ### Hello World with ROS and C++
 Let's start by writing Hello World with ROS and C++. There is standard a standard Hello World program in
-[publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp):
+[code/igvc_training_exercises/src/week2/publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp):
 ```C++
 #include <iostream>
 
@@ -112,7 +112,8 @@ ROS what type of message we will be publishing. In this case, since we want to p
 `std_msgs::Int32` message type. We also need the name of a topic where the messages will be published, which we'll
 set to `my_number`.
 
-(Note: `std_msgs` is a library provided by ROS for creating messages for standard types. [Read more here](http://wiki.ros.org/std_msgs).)
+(Note: `std_msgs` is a library provided by ROS for creating messages for standard types.
+[Read more here](http://wiki.ros.org/std_msgs).)
 
 Add an include for the `std_msgs/Int32.h`:
 ```c++
@@ -123,7 +124,7 @@ Add an include for the `std_msgs/Int32.h`:
 ...
 ```
 
-Then call the function on the `nh` node handle we just created, and store the result in a publisher:
+Then call the `advertise` function on the `nh` node handle we just created, and store the result in a publisher:
 
 ```c++
 int main(int argc, char** argv)
@@ -132,6 +133,7 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
 
   ros::Publisher integer_pub = nh.advertise<std_msgs::Int32>("my_number", 1); // <-- Add this line
+  // nh.advertise<TYPE>(TOPIC_NAME, QUEUE_SIZE)
 
   std::cout << "Hello World!" << std::endl;
   ros::spin();
@@ -241,8 +243,10 @@ data: 13
 
 ### Writing a simple subscriber
 Now that we've written a publisher, let's write a subscriber. Start off by setting up the node with `ros::init` in the 
-[subscriber.cpp](../igvc_training_exercises/src/week2/subscriber.cpp) file, but with a node name of `subscriber` instead.
-Refer back to the [publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp) file or above if you need to.
+[code/igvc_training_exercises/src/week2/subscriber.cpp](../igvc_training_exercises/src/week2/subscriber.cpp) file, but
+with a node name of `subscriber` instead. Refer back to the
+[code/igvc_training_exercises/src/week2/publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp) file
+or above if you need to.
 [Answer](#spoiler 'ros::init(argc, argv, "subscriber")'). Don't forget to add `#include <ros/ros.h>` so that you can use
 the ros functions. There are again four things that we need to do:
 
@@ -257,6 +261,7 @@ Now, we need to create a `ros::Subscriber`. Similar to how we created a `ros::Pu
 by calling the `subscribe` function on the `ros::NodeHandle` like so:
 ```c++
 ros::Subscriber integer_sub = nh.subscribe("my_number", 1, integerCallback);
+// nh.subscribe(TOPIC_NAME, QUEUE_SIZE, CALLBACK_FUNCTION)
 ```
 
 #### 3. Create a callback function
@@ -381,12 +386,19 @@ the message.
   }
   ```
   
-  Notice that we add the `g_` prefix to the variable name. This is to follow thet ROS style guide, so that we can easily
+  Notice that we add the `g_` prefix to the variable name. This is to follow the ROS style guide, so that we can easily
   tell which variables are **global variables**.
   
   How can you tell if a number is even? 
   [Hint](#spoiler 'The % (modulo) operator returns the remainder after division of one number by another.'),
   [Answer](#spoiler 'message.data % 2 == 0').
+  
+  How do you publish to the `even_number` topic to test the node?
+  [Hint](#spoiler 'rostopic pub /even_number <tab>')
+  [Answer](#spoiler 'rostopic pub std_msgs/Int32 "data: 8')
+  
+  How do you echo the `even_number` topic to test that even numbers are being published?
+  [Answer](#spoiler 'rostopic echo /even_number')
   
 </details>
 

--- a/slides/week2/week2.md
+++ b/slides/week2/week2.md
@@ -12,14 +12,16 @@ title: Week 2
 ---
 
 ## Writing a ROS Subscriber and Publisher in C++
-We've looked at how we can publish messages, now it's time to do it in C++. Before we do that though, let's
-figure out how we can write a node in C++ first.
+- We've looked at how we can publish messages, now it's time to do it in C++.
+
+- Before we do that though, let's write a node.
 
 ---
 
 ### Hello World with ROS and C++
-Let's start by writing Hello World with ROS and C++. Starting off with a normal C++ Hello World in
-[publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp):
+- Let's start by writing Hello World with ROS and C++.
+- in [publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp):
+
 ```C++
 #include <iostream>
 
@@ -31,21 +33,22 @@ int main(int argc, char** argv)
 
 ----
 
-We've already compiled this when compiling last week, but just as a recap, we can compile everything in the
-catkin workspace by running
-```bash
-cd catkin_ws # cd to where your catkin workspace is located
-catkin_make
-```
+- We've already compiled this when compiling last week
+- Recap:
+    ```bash
+    cd catkin_ws # cd to where your catkin workspace is located
+    catkin_make
+    ```
 
 ----
 
-- Now, try running the executable with `rosrun`. The ROS package is called `igvc_training_exercises`, and the node is
-called `week2_publisher`.
+- Now, try running the executable with `rosrun`
+    - ROS package: `igvc_training_exercises`
+    - Executable: `week2_publisher`.
 
 - How do you run `week2_publisher`?
 
-`rosrun igvc_training_exercises week2_publisher` <!-- .element: class="fragment" data-fragment-index="1" --> 
+<pre><code class="bash">rosrun igvc_training_exercises week2_publisher</code></pre> <!-- .element: class="fragment" data-fragment-index="1" --> 
 
 ----
 
@@ -61,8 +64,8 @@ it.
 
 ----
 
-- Start by adding an `#include` for the ROS headers at the top of the file. Don't worry about exactly what this does right
-now, as we'll be covering this in general software training later.
+- Start by adding an `#include` for the ROS headers at the top of the file.
+- We'll be covering what this does in general software training later.
 
 ----
 
@@ -87,10 +90,22 @@ now, as we'll be covering this in general software training later.
 
 ---
 
-- `ros::init` initializes a ROS node, and the last argument in the function is the name of the node. To verify that it
-works, save the file and recompile with `catkin_make`. You should still see `Hello World` being printed out. However, we
-can't actually tell that it's working, because the program is exciting right after it prints `Hello World`. To make the
-program wait, add this line after `std::cout`:
+```c++
+ros::init(argc, argv, "NODE_NAME")
+```
+
+- initializes a ROS node
+- last argument in the function is the name of the node
+
+----
+
+- Recompile with `catkin_make` and run the node again to verify that it still works
+- You should still see `Hello World` being printed out
+- However, we can't actually tell that it's working, because the program is exciting immediately
+
+----
+
+- To make the program wait, add `ros::spin()`
 
 ```c++
 int main(int argc, char** argv)
@@ -102,15 +117,15 @@ int main(int argc, char** argv)
 }
 ```
 
----
-
 - For now, don't worry about what `ros::spin()` does. All you need to know is that it stops the program from exiting until
 you do Ctrl-C to stop it.
 
----
+----
 
-- Compile the program again, and run it. Now, you should see that the program doesn't exit. Open up a new terminal window,
-and type in `rosnode list`. You should see the `week2` node show up:
+- Compile the program again, and run it
+    - The program now doesn't exit
+- Open up a new terminal window and type in `rosnode list`
+- You should see the `week2` node show up:
 ```
 /rosout
 /week2
@@ -148,7 +163,10 @@ int main(int argc, char** argv)
 
 #### 2. Create the `ros::Publisher`
 
-- Now we can create a `ros::Publisher` for the node.
+Now we can create a `ros::Publisher` for the node.
+
+----
+
 - `ros::NodeHandle` has a function `advertise` that creates a `ros::Publisher`
 - Need to specify the _type_ of the message
     - Number -> `std_msgs::Int32`.

--- a/slides/week2/week2.md
+++ b/slides/week2/week2.md
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
 }
 ```
 
----
+----
 
 We've already compiled this when compiling last week, but just as a recap, we can compile everything in the
 catkin workspace by running
@@ -38,24 +38,33 @@ cd catkin_ws # cd to where your catkin workspace is located
 catkin_make
 ```
 
----
+----
 
-Now, try running the executable with `rosrun`. The ROS package is called `igvc_training_exercises`, and the node is
-called `week2_publisher`. You can refer back to [week 1](week1.md) on the details of the command if you forgot. Otherwise,
-here's the [answer (Hover over me)](#spoiler "rosrun igvc_training_exercises week2_publisher").
+- Now, try running the executable with `rosrun`. The ROS package is called `igvc_training_exercises`, and the node is
+called `week2_publisher`.
 
-Verify that Hello World correctly prints out:
+- How do you run `week2_publisher`?
+
+`rosrun igvc_training_exercises week2_publisher` <!-- .element: class="fragment" data-fragment-index="1" --> 
+
+----
+
+- Verify that Hello World correctly prints out:
 ```
 Hello World
 ```
 
----
+----
 
-Although we have a Hello World executable, this isn't a node yet. To make this a proper ROS node, we need to initialize
+- Although we have a Hello World executable, this isn't a node yet. To make this a proper ROS node, we need to initialize
 it.
 
-Start by adding an *include* for the ROS headers at the top of the file. Don't worry about exactly what this does right
+----
+
+- Start by adding an `#include` for the ROS headers at the top of the file. Don't worry about exactly what this does right
 now, as we'll be covering this in general software training later.
+
+----
 
 ```c++
 #include <ros/ros.h> // <-- Add this line
@@ -64,21 +73,21 @@ now, as we'll be covering this in general software training later.
 ...
 ```
 
+----
+
+- Next, add `ros::init(argc, argv, "week2")` above the `std::cout`:
+    ```c++
+    int main(int argc, char** argv)
+    {
+      ros::init(argc, argv, "week2"); // <-- Add this line
+    
+      std::cout << "Hello World!" << std::endl;
+    }
+    ```
+
 ---
 
-Next, add the following line above the `std::cout`:
-```c++
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "week2"); // <-- Add this line
-
-  std::cout << "Hello World!" << std::endl;
-}
-```
-
----
-
-`ros::init` initializes a ROS node, and the last argument in the function is the name of the node. To verify that it
+- `ros::init` initializes a ROS node, and the last argument in the function is the name of the node. To verify that it
 works, save the file and recompile with `catkin_make`. You should still see `Hello World` being printed out. However, we
 can't actually tell that it's working, because the program is exciting right after it prints `Hello World`. To make the
 program wait, add this line after `std::cout`:
@@ -95,12 +104,12 @@ int main(int argc, char** argv)
 
 ---
 
-For now, don't worry about what `ros::spin()` does. All you need to know is that it stops the program from exiting until
+- For now, don't worry about what `ros::spin()` does. All you need to know is that it stops the program from exiting until
 you do Ctrl-C to stop it.
 
 ---
 
-Compile the program again, and run it. Now, you should see that the program doesn't exit. Open up a new terminal window,
+- Compile the program again, and run it. Now, you should see that the program doesn't exit. Open up a new terminal window,
 and type in `rosnode list`. You should see the `week2` node show up:
 ```
 /rosout
@@ -110,17 +119,19 @@ and type in `rosnode list`. You should see the `week2` node show up:
 ---
 
 ### Writing a simple publisher
-Now, let's write a simple publisher that publishes a number. To do that, we need to do two things:
+Now, let's write a simple publisher that publishes a number. To do that, we need to do four things:
 
-1. Create the `ros::Publisher`
+----
 
-To do this, we first need to create a `ros::NodeHandle`. You can think of the `ros::NodeHandle` as a "handle" for the
-ROS node - it acts as the main access point for a lot of the ROS functionality, such as creating ROS publishers and
-subscribers.
+#### 1. Create a `ros::NodeHandle`
 
----
+- `ros::NodeHandle` as a "handle" for the ROS node
+- Main access point for a lot of the ROS functionality
+    - Creating ROS publishers and subscribers.
 
-Create a `ros::NodeHandle` by adding the following line in the main function:
+----
+
+- Create a `ros::NodeHandle` by adding the following line in the main function:
 
 ```c++
 int main(int argc, char** argv)
@@ -133,15 +144,20 @@ int main(int argc, char** argv)
 }
 ```
 
----
+----
 
-After creating the `ros::NodeHandle`, we can now create a `ros::Publisher` for the node. `ros::NodeHandle` has a function
-`advertise` that creates a `ros::Publisher` and returns it. Before we create the `ros::Publisher` though, we need to tell
-ROS what message type we will be publishing. In this case, since we want to publish a number, we can use the built-in
-`std_msgs::Int32` message type. We also need the name of a topic to which we'll be publishing the messages on, which we'll
-set to `my_number`
+#### 2. Create the `ros::Publisher`
 
----
+- Now we can create a `ros::Publisher` for the node.
+- `ros::NodeHandle` has a function `advertise` that creates a `ros::Publisher`
+- Need to specify the _type_ of the message
+    - Number -> `std_msgs::Int32`.
+- Also need a topic name
+    - `my_number`
+
+`std_msgs` is a library provided by ROS for creating messages for standard types
+
+----
 
 Add an include for the `std_msgs/Int32.h`:
 ```c++
@@ -152,7 +168,7 @@ Add an include for the `std_msgs/Int32.h`:
 ...
 ```
 
----
+----
 
 Then call the function on the `nh` node handle we just created, and store the result in a publisher:
 
@@ -162,24 +178,33 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "week2");
   ros::NodeHandle nh;
 
-  ros::Publisher integer_pub = nh.advertise<std_msgs::Int32>("my_number", 1); // <-- Add this line
+  // Add the line below
+  ros::Publisher integer_pub = nh.advertise<std_msgs::Int32>("my_number", 1);
 
   std::cout << "Hello World!" << std::endl;
   ros::spin();
 }
 ```
 
----
+----
 
-Notice that we specify the type of the message, `std_msgs::Int32`, as a **template argument** to the `advertise` function.
-Don't worry about the details of how that works for now, we'll cover templates in a later week during general software
-training. We specify the topic name as the first argument, and the queue size in the second argument. We have a queue size
-of 1 set, meaning that we only want to publish the newest message if. Don't worry about the queue size for now.
+`nh.advertise<TYPE>(TOPIC_NAME, QUEUE_SIZE)`
 
----
+- Specify the type of the message, `std_msgs::Int32`, as a **template argument** to the `advertise` function
+- We'll cover templates in a later week during general software training
+- Queue size of 1 => only want to publish the newest message if
+    - Don't worry about the queue size
+    
+----
 
-Now that we've got a publisher, let's publish a message. To do that, we first need to create the message which we want to
-publish in a variable.
+#### 3. Create the message to be published
+
+Now that we've got a publisher, let's publish a message.
+- Create the message which we want to publish in a variable.
+
+----
+
+- Since the type of the message is `std_msgs::Int32`, we make a variable of the same type
 
 ```c++
 int main(int argc, char** argv)
@@ -196,12 +221,17 @@ int main(int argc, char** argv)
 }
 ```
 
----
+----
 
-After creating the message variable, we need to assign the message some data. To find out what **fields** are in a message,
-we can make use of Clion's handy autocomplete. Type `message.` in the line below, and Clion should show the different fields
-of a particular variable. In this case, we see that the `std_msgs::Int32` type has one field called `data`, which has a type
-of `int`. Set the variable to any number you like:
+- Need to assign the message some data
+- To find out what **fields** are in a message, we can make use of Clion's handy autocomplete
+- Type `message.` in the line below
+    - clion's autocomplete should show fields
+    - one field `data` of type `int`
+
+----
+
+- set the `message.data` to any number you like:
 
 ```c++
 int main(int argc, char** argv)
@@ -219,9 +249,11 @@ int main(int argc, char** argv)
 }
 ```
 
----
+----
 
-Finally, we can publish the message by calling `integer_pub.publish` and passing the `std_msgs::Int32` message we just created
+#### 4. Call the `publish()` function for the `ros::Publisher`
+
+To actually publish the message, we call `integer_pub.publish` and pass the `std_msgs::Int32` message we just created
 as an argument:
 
 ```c++
@@ -241,18 +273,14 @@ int main(int argc, char** argv)
 }
 ```
 
----
+----
 
-One problem right now though is that the publisher needs to wait for the subscriber to connect first before publishing,
-otherwise the message will be published before the subscriber can connect. A simple, though not the best fix we can do
-is to add in a `ros::Duration(1).sleep()` to make the program sleep for one second before publishing:
+- One problem: publisher needs to wait for the subscriber to connect first before publishing
+    - Otherwise message will be published before the subscriber will see it
+- Add `ros::Duration(1).sleep()` to sleep for one second
 
 ```c++
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "week2");
-  ros::NodeHandle nh;
-
+  ...
   ros::Publisher integer_pub = nh.advertise<std_msgs::Int32>("my_number", 1);
 
   ros::Duration(1).sleep() // <-- Add in a sleep here to give time to subscribers to connect.
@@ -260,57 +288,85 @@ int main(int argc, char** argv)
   std_msgs::Int32 message;
   message.data = 13;
   integer_pub.publish(message);
-
-  std::cout << "Hello World!" << std::endl;
-  ros::spin();
-}
+  ...
 ```
 
----
+----
 
-Compile again with `catkin_make`, then run the node with `rosrun`. A message should be published to the `my_number` topic
-with the number you sent. What command can you run to see the message that is published?
-[Hint](#spoiler "rostopic echo") [Answer](#spoiler "rostopic echo /my_number").
+#### Checking that the publisher works
 
+- Compile with `catkin_make`, then run with `rosrun`
+- How do you run the node? (The name of the executable is `week2_safety_node`)
+    <ul><li><pre><code>rosrun igvc_training_exercises week2_publisher</code></pre></li></ul><!-- .element: class="fragment" data-fragment-index="1" --> 
+<li><p>A message should be published to the `my_number` topic</p></li> <!-- .element: class="fragment" data-fragment-index="2" --> 
+<li><p>How do you see the message that the node published?</p></li> <!-- .element: class="fragment" data-fragment-index="2" --> 
+    <ul><li><pre><code>rostopic echo /my_number</code></pre></li></ul> <!-- .element: class="fragment" data-fragment-index="3" --> 
+
+----
+ 
 Make sure you run the command before you launch the `week2` node. You should see something like this.
 ```
 data: 13
----
 ```
+
 
 ---
 
 ### Writing a simple subscriber
-Now that we've written a publisher, let's write a subscriber. Start off by setting up the node with `ros::init` in the 
-[subscriber.cpp](../igvc_training_exercises/src/week2/subscriber.cpp) file, but with a node name of `subscriber` instead.
-Refer back to the [publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp) file or above if you need to.
-[Answer](#spoiler 'ros::init(argc, argv, "subscriber")'). Don't forget to add `#include <ros/ros.h>` so that you can use
-the ros functions.
+Now that we've written a publisher, let's write a subscriber
 
----
+----
 
-Next, since we need to do ROS things, ie. create a Subscriber, we need a `ros::NodeHandle` also. Create one like before
-again. [Answer](#spoiler 'ros::NodeHandle nh')
+#### 0. Blank main to ROS node
 
----
+- Start off with [code/igvc_training_exercises/src/week2/subscriber.cpp](../igvc_training_exercises/src/week2/subscriber.cpp)
+- Node name of `subscriber` instead
+- Refer back to the
+[code/igvc_training_exercises/src/week2/publisher.cpp](../igvc_training_exercises/src/week2/publisher.cpp) if you need to
+- Don't forget `#include <ros/ros.h>`
+- There are again _four_ things that we need to do:
 
-Now, we need to create a `ros::Subscriber`. Similar to how we created a `ros::Publisher`, we can create a `ros::Subscriber`
-by calling the `subscribe` function on the `ros::NodeHandle` like so:
-```c++
-ros::Subscriber integer_sub = nh.subscribe("my_number", 1, integerCallback);
-```
+----
 
----
+#### 1. Create a `ros::NodeHandle`
 
-One thing different about writing a `ros::Subscriber` is that we need to write a **callback function**, which in here would
-be the `integerCallback` function (which we haven't written yet, so Clion gives us an error).
+Since we need to do ROS things, ie. create a Subscriber, we need a `ros::NodeHandle` also
 
----
+- Create one like before again
+- How do you create a `ros::NodeHandle`?
+<ul><li><pre><code>ros::NodeHandle nh;</code></pre></li></ul> <!-- .element: class="fragment" data-fragment-index="1" --> 
 
-#### ROS Subscribers and callbacks
-What is a **callback function**? For a ROS subscriber **callback function** is a function that is called when a new message
-is received. For example, in the example above, we've told ROS that we want the `integerCallback` function to be called
-whenever we receive a message. So, if the `integerCallback` function was something like below
+----
+
+#### 2. Create a `ros::Subscriber`
+
+- Now, we need to create a `ros::Subscriber`.
+    - Similar to `ros::Publisher`, we can create a `ros::Subscriber` by calling the `subscribe` function on
+    `ros::NodeHandle`:
+    ```c++
+    ros::Subscriber integer_sub = nh.subscribe("my_number", 1, integerCallback);
+    ```
+<li><pre><code>nh.subscribe(TOPIC_NAME, QUEUE_SIZE, CALLBACK_FUNCTION);</code></pre></li> <!-- .element: class="fragment" data-fragment-index="1" --> 
+
+----
+
+#### 3. Create a callback function
+
+- One thing different is that we need to write a **callback function** (the `integerCallback` function)
+- We haven't written yet, so Clion gives us an error
+
+----
+
+##### What is a callback function?
+
+- In general, a **callback function** is a function which is passed into some other function
+    - Called when some _event_ happens
+- For ROS subscribers, the event is when a message is received
+    - The **callback function** is called when the ROS subscriber received a new message
+    
+----
+
+- For example, if the `integerCallback` function was something like below
 
 ```c++
 void integerCallback(std_msgs::Int32 message)
@@ -319,55 +375,61 @@ void integerCallback(std_msgs::Int32 message)
 }
 ```
 
-then you can understand it as if the ROS library was calling your **callback function** with the message that was received:
+- Understand it as the ROS library calling your **callback function** with the new message
 
 ```c++
 integerCallback(new_message) // You can imagine that this is happening somewhere.
 ```
 
----
+----
 
-#### Creating the callback function and ROS_INFO_STREAM
-Let's create the callback function. Add this function above the `main` function:
+##### Creating the callback function and ROS_INFO_STREAM
+- Let's create the callback function. Add this function above the `main` function:
+    ```c++
+    void integerCallback(std_msgs::Int32 message)
+    {
+      ROS_INFO_STREAM("I received a message: " << message.data);
+    }
+    ```
 
-```c++
-void integerCallback(std_msgs::Int32 message)
-{
-  ROS_INFO_STREAM("I received a message: " << message.data);
-}
-```
+<pre><code class="c++">ROS_INFO_STREAM</code></pre>
+<ul>
+    <li>Convenient method that ROS provides us for logging things</li>
+    <li>Usually better than `std::cout` beacuse also includes a timestamp</li>
+</ul>
+    
+----
 
----
+#### Testing the subscriber
 
-One thing to notice is that instead of using `std::cout`, we are using `ROS_INFO_STREAM` here. `ROS_INFO_STREAM` is a
-convenient method that ROS provides us for logging things. Usually, it is better to use `ROS_INFO_STREAM` than just
-`std::cout`, because `ROS_INFO_STREAM` also includes a timestamp.
+- Try compiling with `catkin_make` and testing it out
+- Run the subscriber node first with `rosrun`, then run the publisher node
 
-Try compiling with `catkin_make` and testing it out. Run the subscriber node first with rosrun
-([Answer](#spoiler "rosrun igvc_training_exercises week2_subscriber")), then running the publisher node as before.
+And...... nothing gets printed. What's happening? <!-- .element: class="fragment" data-fragment-index="1" --> 
 
----
+----
 
-And...... nothing gets printed. What's happening?
+#### 4. `ros::spin()`
+The subscriber node doesn't have the `ros::spin`
 
----
+----
 
-#### ros::spin()
-The reason why nothing is happening is because the subscriber node doesn't have the `ros::spin` line that we put in the
-publisher node.
+##### What does `ros::spin()` do
 
-Besides stopping the program from exiting until we hit Ctrl-C, calling `ros::spin` also hands control of the program to
-ROS, so that ROS can do all the behind-the-scenes work. In this case, this would be calling the respective callback
-functions when a new message comes in.
+- Stops the program from exiting until we hit Ctrl-C
+- Hands control of the program to ROS, so that ROS can do all the behind-the-scenes work
+    - Allow ROS to call the **callback function** when a new message is received
+    
+----
 
----
+- Add the missing `ros::spin` function right after we call `nh.subscribe`
+- Recompile and run
+    - Should see the subscriber print out the message correctly
+    ```
+    [ INFO] [1565078804.617569525]: I received a message: 13
+    ```
 
-Let's add the missing `ros::spin` function right after we call `nh.subscribe`, and then recompile. Now, when you run the
-subscriber and publisher, you should see the subscriber print out the message correctly:
-
-```
-[ INFO] [1565078804.617569525]: I received a message: 13
-```
+----
 
 If you're not seeing the message print correctly, make sure that you run the subscriber node first, and then the
 publisher node afterwards, otherwise the publisher node might publish before the subscriber node has a chance to receive
@@ -375,90 +437,12 @@ the message.
 
 ---
 
-## Exercises
-<details>
-  <summary>1. A publisher that prints a sequence of numbers</summary>
-  
-  Now that you've written a simple publisher and subscriber, instead of publishing just a single number, publish the
-  numbers from 0 to 99 in [exercises/loop_publisher.cpp](../igvc_training_exercises/src/week2/exercises/loop_publisher.cpp)
-  on the same `my_number` topic. To do this, you will need to use a for loop. In case you forgot how to write a for loop:
+## Your Turn
 
-  ```
-  for (int i = 0; i < 100; i++)
-  {
-  }
-  ```
-</details>
-
-<details>
-  <summary>2. A subscriber for <code>std_msgs::String</code></summary>
-  
-  Write a subscriber that subscribes to the `/warning` topic with the `std_msgs::String` message type, and print out the
-  contents of the message received in the callback function using `ROS_WARN_STREAM` instead of `ROS_INFO_STREAM`.
-  
-  Remember to `#include <std_msgs::String>` to be able to use that type.
-  
-  How can you test that your subscriber is working? 
-  [Hint](#spoiler 'Use the "rostopic pub" command. Tab-completion works here, so keep pressing tab.'),
-  [Answer](#spoiler 'rostopic pub /my_string std_msgs/String "data: \'Hello World!\'"').
-  
-</details>
-
-<details>
-  <summary>3. A subscriber that publishes if the received number is even</summary>
-  
-  Write a subscriber that subscribes to the same `my_number` topic as before in the
-  [exercises/even_publisher.cpp](../igvc_training_exercises/src/week2/exercises/even_publisher.cpp).
-  Instead of just printing it out though, this time have the node check if the number even. If the number is even,
-  have the node publish the received number to a new topic `even_number`, otherwise do nothing.
-  
-  This will require you to make the `ros::Publisher` a **global variable** instead of a **local variable** inside of the `main`
-  function, so that you can use the publisher variable inside the callback.
-  
-  Instead of defining the `ros::Publisher` as a **local variable** inside of the main function, ie.
-  ```c++
-  int main(int argc, char** argv)
-  {
-    ...
-    ros::Publisher even_publisher = nh.advertise<std_msgs::Int32>("even_number", 1);
-  }
-  ```
-  
-  Define it as a **global variable** right below the includes, ie.
-  
-  ```c++
-  ros::Publisher g_even_publisher;
-  int main(int argc, char** argv)
-  {
-    ...
-    g_even_publisher = nh.advertise<std_msgs::Int32>("even_number", 1);
-  }
-  ```
-  
-  Notice that we add the `g_` prefix to the variable name. This is to follow thet ROS style guide, so that we can easily
-  tell which variables are **global variables**.
-  
-  How can you tell if a number is even? 
-  [Hint](#spoiler 'The % (modulo) operator returns the remainder after division of one number by another.'),
-  [Answer](#spoiler 'message.data % 2 == 0').
-  
-</details>
-
-<details>
-  <summary>4. A "safety" node for the simulator</summary>
-  
-  Write a node that's actually (somewhat) useful: A "safety" node that takes in `geometry_msgs/Twist` commands,
-  and if the linear speed is too high, send a command with all 0s instead telling the robot to stop.
-  
-  Write this node in
-  [exercises/safety_node.cpp](../igvc_training_exercises/src/week2/exercises/safety_node.cpp).
-  
-  We want to stop the robot if the **speed** is above a certain limit. We can do this easily by taking the absolute
-  value of the velocity with the `std::abs` function.
-  
-  [Hint](#spoiler 'Have the node read from a topic like "/oswin/velocity_unsafe". You can then either rostopic pub
-  or use the teleop_twist_keyboard command with the topic set to "/oswin/velocity_unsafe" to test it out')
-</details>
+- Follow either the markdown version or the slides on the github repo
+<ul><li><a href="https://github.com/RoboJackets/ros-training">github.com/RoboJackets/ros-training</a></li></ul>
+- Show us the finished Publisher and Subscriber working
+- If you're done with both, there are extra exercises in the markdown version
 
 ---
 
@@ -466,32 +450,30 @@ the message.
 
 ----
 
-- [Writing a ROS node](#hello-world-with-ros-and-c)
-    + Using `ros::init(argc, argv, "NODE NAME HERE");` to create a ROS Node
-    + `ros::spin()` so that nodes don't exit
+- [Creating a ROS Node](#/3)
+    + `ros::init(argc, argv, "NODE_NAME")`
 
 ----
 
-- [Writing a ROS publisher](#writing-a-simple-publisher)
-    + Creating a `ros::NodeHandle` to allow Nodes to do ROS things
-    + Using `nh.advertise` to create a publisher
-    + Using the `.publish` method on a publisher to publish a message on a topic
+- [Writing A ROS Publisher](#/7)
+    + Need a `ros::NodeHandle`
+    + `ros::Publisher publisher = nh.advertise<MESSAGE_TYPE>(TOPIC, QUEUE_SIZE)`
+    + Create the message
+    + `publisher.publish(message)`
 
 ----
 
-- [Writing a ROS subscriber](#writing-a-simple-subscriber)
-    + Using `nh.subscribe` to create a subscriber
-    + Creating a **callback function** to receive messages from the subscribed topic
-    + `ros::spin()` as a "behind-the-scenes" method that calls the callbacks you defined
+- [Writing a ROS Subscriber](#/8)
+    + Need a `ros::NodeHandle`
+    + `ros::Subscriber subscriber = nh.subscribe(TOPIC, QUEUE_SIZE, CALLBACK_FUNCTION)`
+        + A **Callback Function** is called when a new message is received
+    + Create the **callback function**
+    + `ros::spin()` to let ROS handle the messages
 
 ----
-
-And hopefully we've had some practice with writing a few nodes, publishers and subscribers.
-
----
 
 ## Next Week
-Next week we'll learn about launch files and PID, and get to (properly) play with the
+Next week we'll learn about **launch files** and **PID**, and get to (properly) play with the
 simulator.
 
 ---


### PR DESCRIPTION
This PR:
- Fixes the missing `safety_node.cpp`
- Fixes the structure of the markdown instructions by adding more numbered headers
- Makes the slides more "presentation" like by breaking up the content better.